### PR TITLE
Improve README and modernize frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,30 @@
 # Time Series Forecasting of TSMC Stock Prices Using RNNs and ConvNets
-- Project Goals
-    - Predict TSMC’s next-day stock price using historical data.
-    - Compare models: Feedforward, LSTM, GRU, Conv1D.
-    - Deploy predictions via a user-friendly Flask web app.
-    - Allow the user to:
-    - View historical trends.
-    - See next-day predictions.
-    - Compare performance metrics across models.
+
+This project predicts TSMC's next day closing price using a variety of deep learning models.
+The best performing model can be queried through a Flask API and a small React front‑end.
+
+## Features
+
+- Data preprocessing and sequence generation for neural networks
+- Hyperparameter tuning for Feedforward, LSTM, GRU and Conv1D models
+- REST endpoints to trigger predictions
+- Modern React interface for interacting with the API
+
+## Quick Start
+
+### Backend
+
+```bash
+pip install -r requirements.txt
+python backend/src/api/app.py
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The front‑end will be available at `http://localhost:5173` and communicates with the Flask API on port `5000` by default.

--- a/backend/src/api/app.py
+++ b/backend/src/api/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask
 from flask_cors import CORS
 from src.api.routes.prediction_routes import prediction_bp
 
@@ -8,6 +8,5 @@ CORS(app)
 app.register_blueprint(prediction_bp)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/src/api/routes/prediction_routes.py
+++ b/backend/src/api/routes/prediction_routes.py
@@ -1,9 +1,15 @@
 from flask import Blueprint, request, jsonify
-from src.api.models.prediction import lstm_prediction, gru_prediction, conv1d_prediction, ffn_prediction
+from src.api.models.prediction import (
+    lstm_prediction,
+    gru_prediction,
+    conv1d_prediction,
+    ffn_prediction,
+)
 
-prediction_bp = Blueprint('prediction', __name__, url_prefix="api/predict")
+prediction_bp = Blueprint("prediction", __name__, url_prefix="/api")
 
-@prediction_bp.route("/", methods=["POST"])
+
+@prediction_bp.post("/predict")
 def predict():
     model = request.get_json().get("model")
     if model == "lstm":
@@ -11,9 +17,11 @@ def predict():
     elif model == "gru":
         result = gru_prediction()
     elif model == "conv1d":
-        result == conv1d_prediction()
+        result = conv1d_prediction()
     elif model == "ffn":
         result = ffn_prediction()
     else:
-        return jsonify({"error": "Invaild model name"}), 400
+        return jsonify({"error": "Invalid model name"}), 400
+
+    return jsonify(result)
         

--- a/frontend/src/pages/PredictionPage.css
+++ b/frontend/src/pages/PredictionPage.css
@@ -1,0 +1,20 @@
+.prediction-container {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.form-controls {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+.result {
+  margin-top: 2rem;
+  background: #f5f5f5;
+  padding: 1rem;
+  border-radius: 4px;
+  color: #222;
+}

--- a/frontend/src/pages/PredictionPage.jsx
+++ b/frontend/src/pages/PredictionPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axios from "axios";
+import "./PredictionPage.css";
 
 const models = ["lstm", "gru", "conv1d", "ffn"];
 
@@ -11,7 +12,7 @@ function PredictionPage() {
   const handlePredict = async () => {
     setLoading(true);
     try {
-      const res = await axios.post("http://localhost:5000/api/predict/", { model });
+      const res = await axios.post("http://localhost:5000/api/predict", { model });
       setResult(res.data);
     } catch (err) {
       console.error("Prediction error:", err);
@@ -20,21 +21,23 @@ function PredictionPage() {
   };
 
   return (
-    <div style={{ padding: "2rem" }}>
+    <div className="prediction-container">
       <h1>Stock Prediction</h1>
-      <select value={model} onChange={(e) => setModel(e.target.value)}>
-        {models.map((m) => (
-          <option key={m} value={m}>
-            {m.toUpperCase()}
-          </option>
-        ))}
-      </select>
-      <button onClick={handlePredict} disabled={loading} style={{ marginLeft: "1rem" }}>
-        {loading ? "Predicting..." : "Predict"}
-      </button>
+      <div className="form-controls">
+        <select value={model} onChange={(e) => setModel(e.target.value)}>
+          {models.map((m) => (
+            <option key={m} value={m}>
+              {m.toUpperCase()}
+            </option>
+          ))}
+        </select>
+        <button onClick={handlePredict} disabled={loading}>
+          {loading ? "Predicting..." : "Predict"}
+        </button>
+      </div>
 
       {result && (
-        <div style={{ marginTop: "2rem" }}>
+        <div className="result">
           <h3>Validation MAE: ${result.mae_val_dollar.toFixed(2)}</h3>
           <h3>Test MAE: ${result.mae_test_dollar.toFixed(2)}</h3>
           <h4>Test MAE (%): {result.mae_test_percent.toFixed(2)}%</h4>


### PR DESCRIPTION
## Summary
- enhance project README
- fix prediction endpoint routing and return value
- clean up Flask app entry
- update React prediction page and add modern styles

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68483c329818832997817d1192b94035